### PR TITLE
Change function name & add construct for PHP 7

### DIFF
--- a/libs/browser.php
+++ b/libs/browser.php
@@ -204,7 +204,7 @@
 
 		const OPERATING_SYSTEM_UNKNOWN = 'unknown';
 
-		public function ExposeBrowser($useragent="") {
+		public function __construct($useragent="") {
 			$this->reset();
 			if( $useragent != "" ) {
 				$this->setUserAgent($useragent);


### PR DESCRIPTION
**Deprecated:** Methods with the same name as their class will no be constructors in a future version of PHP; ExposeBrowser has a deprecated constructor in /expose/libs/browser.php on line 135