### PR TITLE
Fix fatal error issue on the lessc.php file

### DIFF
--- a/libs/lessc.php
+++ b/libs/lessc.php
@@ -37,6 +37,7 @@
  * The `lessc_formatter` takes a CSS tree, and dumps it to a formatted string,
  * handling things like indentation.
  */
+if (!class_exists('lessc')) {
 class lessc {
 	static public $VERSION = "v0.3.9";
 	static protected $TRUE = array("keyword", "true");
@@ -2031,9 +2032,11 @@ class lessc {
 		'yellowgreen' => '154,205,50'
 	);
 }
+}
 
 // responsible for taking a string of LESS code and converting it into a
 // syntax tree
+if (!class_exists('lessc_parser')) {
 class lessc_parser {
 	static protected $nextBlockId = 0; // used to uniquely identify blocks
 
@@ -3353,7 +3356,9 @@ class lessc_parser {
 	}
 
 }
+}
 
+if (!class_exists('lessc_formatter_classic')) {
 class lessc_formatter_classic {
 	public $indentChar = "  ";
 
@@ -3448,7 +3453,9 @@ class lessc_formatter_classic {
 		}
 	}
 }
+}
 
+if (!class_exists('lessc_formatter_compressed')) {
 class lessc_formatter_compressed extends lessc_formatter_classic {
 	public $disableSingle = true;
 	public $open = "{";
@@ -3461,11 +3468,13 @@ class lessc_formatter_compressed extends lessc_formatter_classic {
 		return "";
 	}
 }
+}
 
+if (!class_exists('lessc_formatter_lessjs')){
 class lessc_formatter_lessjs extends lessc_formatter_classic {
 	public $disableSingle = true;
 	public $breakSelectors = true;
 	public $assignSeparator = ": ";
 	public $selectorSeparator = ",";
 }
-
+}


### PR DESCRIPTION
Showing error **lessc** object with Kuena Forum lessc.php file. That's why we use **if** statement **!class_exists** for fixing this issue.